### PR TITLE
25-05-23 punp2002

### DIFF
--- a/SEMIProject-boot/src/main/java/edu/kh/semi/board/controller/FreeBoardController.java
+++ b/SEMIProject-boot/src/main/java/edu/kh/semi/board/controller/FreeBoardController.java
@@ -31,7 +31,8 @@ public class FreeBoardController {
 
 	/** 목록 조회 */
 	@GetMapping("/list")
-	public String list(Model model, @RequestParam(value = "cp", required = false, defaultValue = "1") int cp) {
+	public String list(Model model, @RequestParam(value = "cp", 
+	required = false, defaultValue = "1") int cp) {
 		int listCount = service.getListCount();
 		Pagination pagination = new Pagination(cp, listCount);
 
@@ -49,27 +50,37 @@ public class FreeBoardController {
 	 * @param image
 	 * @return
 	 */
-	@PostMapping("/freeBoard/write")
+	@PostMapping("/write")
 	public String Write(Board board, HttpSession session,
-			@RequestParam(value = "boardImage", required = false) MultipartFile image) {
-		Member loginMember = (Member) session.getAttribute("loginMember");
-		board.setMemberNo((int) loginMember.getMemberNo());
-		board.setBoardCode(2);
+	        @RequestParam(value = "boardImage", required = false) MultipartFile image) {
 
-		int result = service.insertFreeBoard(board);
+	    // 로그인 여부 확인
+	    Member loginMember = (Member) session.getAttribute("loginMember");
+	    if (loginMember == null) {
+	        // 로그인 안 되어 있으면 로그인 페이지로 리다이렉트
+	        return "redirect:/member/login";
+	    }
 
-		if (result > 0) {
-			// 성공 시
-			// 이미지 저장은 선택 처리
-			if (image != null && !image.isEmpty()) {
-				// 별도 이미지 처리 메서드
-			}
-			return "redirect:/free/list";
+	    // Member 객체의 번호 설정 (int 캐스팅은 DTO 타입에 따라 유지)
+	    board.setMemberNo((int) loginMember.getMemberNo());
 
-		} else {
-			// 실패 시
-			return "redirect:/error";
-		}
+	    // 자유 게시판 코드 설정
+	    board.setBoardCode(2); // 2: 자유게시판
+
+	    int result = service.insertFreeBoard(board, image);
+
+	    if (result > 0) {
+	        // 성공 시
+	        return "redirect:/free/list";
+	    } else {
+	        // 실패 시
+	        return "redirect:/error";
+	    }
+	}
+	
+	@GetMapping("/write")
+	public String showWriteForm() {
+	    return "board/free/freeboardwriting"; // 버튼 get요청 용
 	}
 
 	/**
@@ -80,16 +91,23 @@ public class FreeBoardController {
 	 * @return
 	 */
 	@GetMapping("/view/{boardNo}")
-	public String detail(@PathVariable("boardNo") Long boardNo, Model model) {
+	public String detail(@PathVariable("boardNo") int boardNo, @RequestParam(value = "edit", required = false, defaultValue = "false") boolean edit, Model model) {
 		service.updateReadCount(boardNo); // 조회수 증가
 		
 		Board board = service.getFreeBoard(boardNo);
 
 		model.addAttribute("board", board);
+		
+		model.addAttribute("editMode", edit);
 
-		// model.addAttribute("commentList", service.getCommentList(boardNo));
+	    // 수정모드(edit)가 아닐 때만 댓글 불러오기
+	    if (!edit) {
+	        model.addAttribute("commentList", service.getCommentList(boardNo));
+	    }
 		return "board/free/freeboarddetail";
 	}
+	
+	
 
 	/**
 	 * 게시글 수정 (AJAX 방식)
@@ -104,15 +122,15 @@ public class FreeBoardController {
 	 */
 	@PostMapping("/update")
 	@ResponseBody
-	public Map<String, Object> updateFreeBoard(@RequestParam("boardNo") Long boardNo,
+	public Map<String, Object> updateFreeBoard(@RequestParam("boardNo") int boardNo,
 			@RequestParam("boardTitle") String boardTitle, @RequestParam("boardContent") String boardContent,
-			@RequestParam("memberNo") Long memberNo,
+			@RequestParam("memberNo") int memberNo,
 			@RequestParam(value = "boardImage", required = false) MultipartFile boardImage, HttpSession session) {
 
 		Map<String, Object> response = new HashMap<>();
 		Member loginMember = (Member) session.getAttribute("loginMember");
 
-		if (loginMember == null || memberNo == null || !memberNo.equals((long) loginMember.getMemberNo())) {
+		if (loginMember == null || loginMember.getMemberNo() != memberNo) {
 			response.put("success", false);
 			response.put("message", "수정 권한이 없습니다.");
 			return response;
@@ -141,11 +159,11 @@ public class FreeBoardController {
 	 * @return
 	 */
 	@GetMapping("/delete/{boardNo}")
-	public String deleteBoard(@PathVariable("boardNo") Long boardNo, HttpSession session, RedirectAttributes ra) {
+	public String deleteBoard(@PathVariable("boardNo") int boardNo, HttpSession session, RedirectAttributes ra) {
 		Member loginMember = (Member) session.getAttribute("loginMember");
 		Board board = service.getFreeBoard(boardNo);
 
-		if (loginMember == null || !Long.valueOf(loginMember.getMemberNo()).equals(board.getMemberNo())) {
+		if (loginMember == null || loginMember.getMemberNo() != board.getMemberNo()) {
 			ra.addFlashAttribute("message", "삭제 권한이 없습니다.");
 			return "redirect:/free/list";
 		}

--- a/SEMIProject-boot/src/main/java/edu/kh/semi/board/model/mapper/FreeBoardMapper.java
+++ b/SEMIProject-boot/src/main/java/edu/kh/semi/board/model/mapper/FreeBoardMapper.java
@@ -15,14 +15,15 @@ public interface FreeBoardMapper {
 	int selectFreeListCount();
 	int insertFreeBoard(Board board);
 	Board selectFreeBoard(int boardNo);
-	int updateReadCount(Long boardNo);
+	int updateReadCount(int boardNo);
 	int updateFreeBoard(Board board);
 	// 검색 기능 추가 김동준 2025-05-22
     List<Board> searchByKeyword(@Param("query") String query);
 	List<Board> selectByMember(int memberNo);
-	int deleteBoard(Long boardNo);
+	int deleteBoard(int boardNo);
 	void deleteBoardImage(int i);
 	void insertBoardImage(BoardImg image);
+	int insertBoardImage(@Param("boardNo") int boardNo, @Param("imgPath") String imgPath);
 	
 
 }

--- a/SEMIProject-boot/src/main/java/edu/kh/semi/board/model/service/FreeBoardService.java
+++ b/SEMIProject-boot/src/main/java/edu/kh/semi/board/model/service/FreeBoardService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 import edu.kh.semi.board.model.dto.Board;
+import edu.kh.semi.board.model.dto.Comment;
 import edu.kh.semi.board.model.dto.Pagination;
 
 
@@ -13,7 +14,7 @@ public interface FreeBoardService {
     
 	List<Board> getList(Pagination pagination);
 	int getListCount();
-	int insertFreeBoard(Board board);
+
 	Board getFreeBoard(int boardNo);	
 	void updateReadCount(int boardNo);
 	int updateBoard(Board board, MultipartFile boardImage);
@@ -22,5 +23,8 @@ public interface FreeBoardService {
 	List<Board> searchByKeyword(String query);
 	List<Board> selectByMember(int memberNo);
 	int deleteBoard(int boardNo);
+	List<Comment> getCommentList(int boardNo);
+	
+	int insertFreeBoard(Board board, MultipartFile image); // 
 	
 }

--- a/SEMIProject-boot/src/main/resources/mappers/freeboard-mapper.xml
+++ b/SEMIProject-boot/src/main/resources/mappers/freeboard-mapper.xml
@@ -34,15 +34,20 @@
 	</select>
 
 	<!-- 자유게시판 글쓰기 -->
-	<insert id="insertFreeBoard" parameterType="Board"
-		useGeneratedKeys="true" keyProperty="boardNo">
+	<insert id="insertFreeBoard" parameterType="Board">
+		<!-- Oracle에서는 반드시 selectKey 사용 -->
+		<selectKey keyProperty="boardNo" resultType="int"
+			order="BEFORE">
+			SELECT SEQ_BOARD_NO.NEXTVAL FROM DUAL
+		</selectKey>
+
 		INSERT INTO BOARD (
 		BOARD_NO,
 		BOARD_TITLE, BOARD_CONTENT,
 		MEMBER_NO, BOARD_CODE, READ_COUNT,
 		BOARD_DEL_FL, BOARD_WRITE_DATE
 		) VALUES (
-		SEQ_BOARD_NO.NEXTVAL,
+		#{boardNo},
 		#{boardTitle},
 		#{boardContent},
 		#{memberNo},
@@ -52,6 +57,8 @@
 		SYSDATE
 		)
 	</insert>
+
+
 
 	<resultMap id="board_rm" type="Board">
 		<id property="boardNo" column="BOARD_NO" />
@@ -72,7 +79,7 @@
 		<result property="authority" column="AUTHORITY" />
 	</resultMap>
 
-	<select id="selectFreeBoard" parameterType="long"
+	<select id="selectFreeBoard" parameterType="int"
 		resultMap="board_rm">
 		SELECT
 		B.BOARD_NO,
@@ -132,9 +139,10 @@
 	</select>
 
 	<!-- 조회수 증가 -->
-	<update id="updateReadCount" parameterType="long">
+	<update id="updateReadCount" parameterType="int">
 		UPDATE BOARD
-		SET READ_COUNT = READ_COUNT + 1
+		SET
+		READ_COUNT = READ_COUNT + 1
 		WHERE BOARD_NO = #{boardNo}
 	</update>
 
@@ -149,14 +157,14 @@
 	</select>
 
 	<!-- 게시판 삭제 -->
-	<delete id="deleteBoard">
-		DELETE FROM BOARD
-		WHERE BOARD_NO = #{boardNo}
-	</delete>
+	<update id="deleteBoard" parameterType="int">
+		UPDATE BOARD SET
+		BOARD_DEL_FL = 'Y' WHERE BOARD_NO = #{boardNo}
+	</update>
 
 	<!-- 이미지 수정 -->
 	<!-- 기존 이미지 삭제 -->
-	<delete id="deleteBoardImage" parameterType="long">
+	<delete id="deleteBoardImage" parameterType="int">
 		DELETE FROM
 		BOARD_IMAGE
 		WHERE BOARD_NO = #{boardNo}

--- a/SEMIProject-boot/src/main/resources/static/css/free/freeboardwriting.css
+++ b/SEMIProject-boot/src/main/resources/static/css/free/freeboardwriting.css
@@ -95,3 +95,7 @@ body {
   border-radius: 6px;
   cursor: pointer;
 }
+
+#preview {
+  margin-bottom: 10px;
+}

--- a/SEMIProject-boot/src/main/resources/static/js/free/freeboardwriting.js
+++ b/SEMIProject-boot/src/main/resources/static/js/free/freeboardwriting.js
@@ -1,0 +1,15 @@
+document.getElementById("freeImage").addEventListener("change", function (e) {
+  const file = e.target.files[0];
+
+  if (file) {
+    const reader = new FileReader();
+
+    reader.onload = function (event) {
+      const preview = document.getElementById("preview");
+      preview.src = event.target.result;
+      preview.style.display = "block";
+    };
+
+    reader.readAsDataURL(file);
+  }
+});

--- a/SEMIProject-boot/src/main/resources/static/js/free/freecomment.js
+++ b/SEMIProject-boot/src/main/resources/static/js/free/freecomment.js
@@ -1,21 +1,38 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const editMode = document.body.getAttribute("data-edit-mode") === "true";
 
+  if (editMode) {
+    console.log("🛑 수정 모드 - 댓글 JS 작동 중지");
+
+    // DOM에 남아 있을 수 있는 댓글 요소 강제 제거
+    document.querySelector('.comment-section')?.remove();
+    document.querySelector('.comment-form')?.remove();
+    
+    return; // 댓글 관련 로직 실행 중단
+  }
+
+  console.log("✅ 일반 모드 - 댓글 JS 작동 시작");
+
+  // 댓글 기능 요소들
   const boardNo = document.querySelector('.free-title')?.dataset.boardNo;
   const commentListArea = document.querySelector('.comment-section');
   const commentForm = document.querySelector('.comment-form form');
   const commentTextarea = commentForm?.querySelector('textarea');
 
-  // ✅ 댓글 목록 조회
+  if (!boardNo || !commentListArea || !commentForm || !commentTextarea) {
+    console.warn("❗댓글 관련 요소 누락. 초기화 중단");
+    return;
+  }
+
+  // 댓글 목록 조회
   function loadFreeComments() {
     fetch(`/freeComment?boardNo=${boardNo}`)
       .then(res => res.json())
       .then(list => {
-        commentListArea.innerHTML = ''; // 기존 댓글들 제거
-
+        commentListArea.innerHTML = '';
         list.forEach(comment => {
           const commentBox = document.createElement('div');
           commentBox.className = 'comment-box';
-
           commentBox.innerHTML = `
             <div class="comment-header">
               <div class="comment-writer">
@@ -30,7 +47,6 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>
             <div class="comment-content">${comment.commentContent}</div>
           `;
-
           commentListArea.appendChild(commentBox);
         });
       });
@@ -38,8 +54,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   loadFreeComments();
 
-  // ✅ 댓글 등록
-  commentForm?.addEventListener('submit', e => {
+  // 댓글 등록
+  commentForm.addEventListener('submit', e => {
     e.preventDefault();
     const content = commentTextarea.value.trim();
 
@@ -51,11 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
     fetch('/freeComment/insert', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        boardNo,
-        commentContent: content,
-        parentCommentNo: 0
-      })
+      body: JSON.stringify({ boardNo, commentContent: content, parentCommentNo: 0 })
     })
       .then(res => res.text())
       .then(result => {
@@ -68,11 +80,10 @@ document.addEventListener('DOMContentLoaded', () => {
       });
   });
 
-  // ✅ 댓글 수정 / 삭제 이벤트 위임 처리
-  commentListArea?.addEventListener('click', e => {
+  // 댓글 수정/삭제
+  commentListArea.addEventListener('click', e => {
     const target = e.target;
 
-    // 삭제
     if (target.matches('.delete')) {
       e.preventDefault();
       const commentNo = target.closest('.comment-actions').dataset.commentNo;
@@ -81,7 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
         fetch('/freeComment', {
           method: 'DELETE',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(parseInt(commentNo)) // 반드시 JSON 형식으로 보낼 것
+          body: JSON.stringify(parseInt(commentNo))
         })
           .then(res => res.text())
           .then(result => {
@@ -93,7 +104,6 @@ document.addEventListener('DOMContentLoaded', () => {
           });
       }
 
-    // 수정
     } else if (target.matches('.update')) {
       e.preventDefault();
 
@@ -141,10 +151,7 @@ document.addEventListener('DOMContentLoaded', () => {
         fetch('/freeComment', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            commentNo: parseInt(commentNo),
-            commentContent: newContent
-          })
+          body: JSON.stringify({ commentNo: parseInt(commentNo), commentContent: newContent })
         })
           .then(res => res.text())
           .then(result => {
@@ -157,5 +164,9 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
   });
-
 });
+
+function goEditMode() {
+  const boardNo = document.querySelector('.free-title')?.dataset.boardNo;
+  location.href = `/free/view/${boardNo}?edit=true`;
+}

--- a/SEMIProject-boot/src/main/resources/templates/board/free/freeboarddetail.html
+++ b/SEMIProject-boot/src/main/resources/templates/board/free/freeboarddetail.html
@@ -12,76 +12,76 @@
 	<th:block th:replace="~{common/common}"></th:block>
 </head>
 
-<body>
+<body th:data-edit-mode="${editMode}">
 	<th:block th:replace="~{common/header}" />
 
 	<div class="free-detail-container">
 		<div class="free-title-box">
-			<!-- 제목에 boardNo 포함 -->
-			<h1 class="free-title" th:text="${board.boardTitle}"
-				th:attr="data-board-no=${board.boardNo}, data-member-no=${board.memberNo}">자유 게시판 제목</h1>
+			<h1 class="free-title" th:if="${!editMode}" th:text="${board.boardTitle}"
+				th:attr="data-board-no=${board.boardNo}, data-member-no=${board.memberNo}">제목</h1>
+			<input type="text" class="edit-title" th:if="${editMode}" th:value="${board.boardTitle}">
 
 			<div class="free-meta">
 				<div class="writer-info">
-					<img th:src="@{${board.profileImg}}" class="writer-img">
+					<img th:src="${board.profileImg}" class="writer-img">
 					<span th:text="${board.memberNickname}" class="writer-name">작성자</span>
+					<span th:if="${board.authority == 9}" class="admin-badge">[관리자]</span>
 				</div>
 				<div class="date-view">
-					<span th:text="${board.boardWriteDate}">2025.05.21</span>
-					<span th:text="'조회수 ' + ${board.readCount}">조회수 20</span>
+					<span th:text="${board.boardWriteDate}">작성일</span>
+					<span th:text="'조회수 ' + ${board.readCount}">조회수</span>
 				</div>
 			</div>
 		</div>
 
 		<div class="free-body-box">
 			<div class="free-thumbnail" id="thumbnail-area">
-				<img th:if="${board.thumbnail != null}" th:src="@{${board.thumbnail}}" alt="대표 이미지">
+				<img th:if="${board.thumbnail != null}" th:src="${board.thumbnail}" alt="대표 이미지">
+				<input type="file" name="boardImage" accept="image/*" class="edit-image" th:if="${editMode}">
 			</div>
 
-			<div class="free-content" th:text="${board.boardContent}">
-				게시글 본문 내용입니다.
-			</div>
+			<div class="free-content" th:if="${!editMode}" th:text="${board.boardContent}">본문</div>
+			<textarea class="edit-content" th:if="${editMode}" th:text="${board.boardContent}"></textarea>
 		</div>
 
 		<div class="free-btn-area"
 			th:if="${session.loginMember != null and board.memberNo == session.loginMember.memberNo}">
-			<button class="btn modify">수정</button>
-			<button class="btn delete" th:onclick="|confirmDelete(${board.boardNo})|">
-				삭제
-			</button>
+			<button class="btn modify" th:if="${!editMode}" onclick="goEditMode()">수정</button>
+			<button class="btn modify" th:if="${editMode}" onclick="submitUpdate()">저장</button>
+			<button class="btn cancel" th:if="${editMode}"
+				onclick="location.href='@{/free/view/{boardNo}(boardNo=${board.boardNo})}'">취소</button>
+			<button class="btn delete" th:onclick="|confirmDelete(${board.boardNo})|">삭제</button>
 		</div>
 
-		<!-- 목록 버튼은 항상 노출 -->
 		<div class="free-btn-area">
 			<a class="btn back" th:href="@{/free/list}">목록보기</a>
 		</div>
 
+<th:block th:if="${!editMode}">
+  <div class="comment-section"></div>
 
-		<div class="comment-section"></div>
-
-		<!-- 댓글 작성 영역 -->
-		<div class="comment-form" th:if="${session.loginMember != null}">
-			<form onsubmit="return false;">
-				<textarea name="commentContent" placeholder="댓글을 입력하세요."></textarea>
-				<button type="submit">댓글 달기</button>
-			</form>
-		</div>
-	</div>
+  <div class="comment-form" th:if="${session.loginMember != null}">
+    <form onsubmit="return false;">
+      <textarea name="commentContent" placeholder="댓글을 입력하세요."></textarea>
+      <button type="submit">댓글 달기</button>
+    </form>
+  </div>
+</th:block>
 
 	<th:block th:replace="~{common/footer}" />
 	<script th:src="@{/js/free/freeboarddetail.js}"></script>
 	<script th:src="@{/js/free/freecomment.js}"></script>
-	
+
 	<script>
-		window.addEventListener("pageshow", function(event) {
-					const navType = performance.getEntriesByType("navigation")[0]?.type;
-					console.log("pageshow 발생 / navType: ", navType, "/ persisted:", event.persisted);
-					
-					if (event.persisted || navType === "back_forward") {
-						console.log("[뒤로가기 감지] 새로고침 실행");
-						location.reload();
-					}
-				});
+		window.addEventListener("pageshow", function (event) {
+			const navType = performance.getEntriesByType("navigation")[0]?.type;
+			console.log("pageshow 발생 / navType: ", navType, "/ persisted:", event.persisted);
+
+			if (event.persisted || navType === "back_forward") {
+				console.log("[뒤로가기 감지] 새로고침 실행");
+				location.reload();
+			}
+		});
 	</script>
 </body>
 

--- a/SEMIProject-boot/src/main/resources/templates/board/free/freeboardwriting.html
+++ b/SEMIProject-boot/src/main/resources/templates/board/free/freeboardwriting.html
@@ -5,14 +5,15 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>공지 게시판 상세</title>
-	<link rel="stylesheet" href="/boardwriting.css">
+	<link rel="stylesheet" th:href="@{/css/free/freeboardwriting.css}">
+	<th:block th:replace="~{common/common}"></th:block>
 
 </head>
 
 <body>
 	<th:block th:replace="~{common/header}" />
 	<div class="free-write-container">
-		<form action="/freeBoard/write" method="post" enctype="multipart/form-data">
+		<form action="/free/write" method="post" enctype="multipart/form-data">
 
 			<!-- 전체 회색 박스 -->
 			<div class="free-form-box">
@@ -25,6 +26,7 @@
 
 				<!-- 내용 영역 (회색 박스 안, 흰 배경) -->
 				<div class="free-content-area">
+					<img id="preview" style="display:none; max-width:200px; margin-top:10px;" />
 					<textarea name="boardContent" class="free-content" placeholder="내용을 입력해주세요."></textarea>
 				</div>
 
@@ -34,11 +36,14 @@
 			<div class="free-btn-area">
 				<label for="freeImage" class="free-image-btn">사진첨부</label>
 				<input type="file" id="freeImage" name="boardImage" style="display:none;">
+				
 				<button type="submit" class="free-submit-btn">등록하기</button>
 			</div>
 
 		</form>
 	</div>
+	<script th:src="@{/js/free/freeboardwriting.js}"></script>
+	<th:block th:replace="~{common/footer}" />
 </body>
 
 </html>


### PR DESCRIPTION
자유게시판 수정 모드에서 댓글 비노출 문제 해결 기록

자유게시판 글을 수정할 때(?edit=true), 댓글이 계속 보이고 있음

댓글은 수정할 수 있고, 삭제도 가능 → 수정 모드임에도 댓글이 활성 상태


HTML에서 댓글 영역 항상 렌더링됨

<div class="comment-section">이 수정 모드든 아니든 무조건 보임

commentForm 같은 변수를 여러 번 선언 → 오류 발생 후 JS 중단
goEditMode() 함수 없음 수정 버튼 누르면 에러

수정 모드일 땐 댓글 HTML 아예 출력되지 않도록 처리
수정 모드일 경우 댓글 관련 JS 전체 중단 + DOM 제거

goEditMode() 함수 누락되어 있었음 추가

JS로만 DOM을 지워도 일단 보였다가 사라짐
완벽한 비활성화는 HTML 렌더링 자체에서 막는 게 핵심
JS 변수 충돌, 중복 선언, 함수 누락까지 함께 확인해야 함

글쓰기 기능 구현 > 사진 첨부시 미리보기 기능 구현 진행중
